### PR TITLE
Add --web mode: HTTP server with browser UI and chat API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This file summarizes notable project changes grouped into semantic version-style
 
 ## Unreleased
 
-- (nothing yet)
+- CLI: added `--web` and `--web-addr` flags to run Jorin as an HTTP web service.
+- Web: added browser chat UI (`GET /`), chat API (`POST /api/chat`), and health endpoint (`GET /healthz`).
+- Tests: added unit tests for the new web routes and chat request validation.
 
 ## v0.0.10 - 2026-02-06
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Send a single prompt:
 jorin "Refactor function X to be smaller"
 ```
 
+Run as a local web service and open the browser UI:
+
+```bash
+jorin --web --web-addr 127.0.0.1:8080
+```
+
 Pipe stdin into a prompt:
 
 ```bash

--- a/cmd/jorin/cli.go
+++ b/cmd/jorin/cli.go
@@ -23,6 +23,8 @@ type Config struct {
 	promptFileFlag  bool
 	ralph           bool
 	ralphMaxTries   int
+	web             bool
+	webAddr         string
 	versionFlag     bool
 	useResponsesAPI bool
 }
@@ -39,6 +41,8 @@ func parseFlags() Config {
 	promptFileFlag := flag.Bool("prompt-file", false, "Treat first argument as a prompt file")
 	ralph := flag.Bool("ralph", false, "Enable Ralph Wiggum loop instructions")
 	ralphMaxTries := flag.Int("ralph-max-tries", 8, "Maximum Ralph Wiggum loop iterations")
+	web := flag.Bool("web", false, "Run as an HTTP web service")
+	webAddr := flag.String("web-addr", "127.0.0.1:8080", "Address for web service listener")
 	versionFlag := flag.Bool("version", false, "Print version and exit")
 	useResponsesAPI := flag.Bool("use-responses-api", false, "Use the new OpenAI Responses API instead of Chat Completions")
 	flag.Parse()
@@ -55,6 +59,8 @@ func parseFlags() Config {
 		promptFileFlag:  *promptFileFlag,
 		ralph:           *ralph,
 		ralphMaxTries:   *ralphMaxTries,
+		web:             *web,
+		webAddr:         *webAddr,
 		versionFlag:     *versionFlag,
 		useResponsesAPI: *useResponsesAPI,
 	}

--- a/cmd/jorin/main.go
+++ b/cmd/jorin/main.go
@@ -16,12 +16,17 @@ func main() {
 
 	promptMode := resolvePromptMode(cli.promptFlag, cli.promptFileFlag)
 	stdinIsTTY := isTTY(os.Stdin)
-	promptText, scriptArgs, err := resolvePrompt(flag.Args(), promptMode)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "ERR:", err)
-		os.Exit(1)
-	}
+	promptText := ""
+	scriptArgs := []string(nil)
 	noArgs := len(flag.Args()) == 0 && stdinIsTTY
+	if !cli.web {
+		var err error
+		promptText, scriptArgs, err = resolvePrompt(flag.Args(), promptMode)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "ERR:", err)
+			os.Exit(1)
+		}
+	}
 
 	cfg := app.Config{
 		Model:           cli.model,
@@ -31,6 +36,8 @@ func main() {
 		ScriptArgs:      scriptArgs,
 		RalphMaxTries:   cli.ralphMaxTries,
 		UseResponsesAPI: cli.useResponsesAPI,
+		Web:             cli.web,
+		WebAddr:         cli.webAddr,
 		Policy: types.Policy{
 			Readonly: cli.readonly,
 			DryShell: cli.dryShell,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -104,6 +104,8 @@ cat document.md | jorin
 | `--prompt-file` | `false` | Treat the first argument as a prompt file (error if not a readable file). |
 | `--ralph` | `false` | Enable Ralph Wiggum loop instructions in the system prompt. |
 | `--ralph-max-tries` | `8` | Maximum iterations for Ralph Wiggum loop mode. |
+| `--web` | `false` | Run Jorin as an HTTP service with browser UI and JSON API. |
+| `--web-addr` | `127.0.0.1:8080` | Address the web service listens on. |
 | `--version` | `false` | Print version and exit. |
 
 Notes:
@@ -112,6 +114,34 @@ Notes:
   allowlisted substring.
 - If `--deny` is provided, any substring match blocks execution.
 - `--cwd` applies to the `shell` tool only; read/write paths are used as given.
+
+### Web service mode
+
+Start Jorin as a local web app/API server:
+
+```bash
+jorin --web --web-addr 127.0.0.1:8080
+```
+
+Then open `http://127.0.0.1:8080` in your browser.
+
+HTTP endpoints:
+
+- `GET /`: Browser chat UI.
+- `POST /api/chat`: Send/continue chat sessions.
+- `GET /healthz`: Health check endpoint returning `ok`.
+
+`POST /api/chat` request body example:
+
+```json
+{
+  "messages": [
+    {"role": "user", "content": "Refactor this function"},
+    {"role": "assistant", "content": "Sure, share the code."},
+    {"role": "user", "content": "Here it is..."}
+  ]
+}
+```
 
 ### Ralph Wiggum loop mode
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dave1010/jorin/internal/repl"
 	"github.com/dave1010/jorin/internal/repl/commands"
 	"github.com/dave1010/jorin/internal/types"
+	"github.com/dave1010/jorin/internal/web"
 )
 
 // ErrMissingPrompt is returned when no prompt is provided and REPL is not requested.
@@ -34,6 +35,8 @@ type Config struct {
 	Stdout          io.Writer
 	Stderr          io.Writer
 	UseResponsesAPI bool
+	Web             bool
+	WebAddr         string
 }
 
 // App holds the application's dependencies.
@@ -56,10 +59,24 @@ func NewApp(cfg *Config) *App {
 
 // Run wires core dependencies and starts either the REPL or a single prompt run.
 func (a *App) Run(ctx context.Context) error {
+	if a.cfg.Web {
+		return a.runWeb(ctx)
+	}
 	if a.cfg.NoArgs || a.cfg.Repl {
 		return a.runRepl(ctx)
 	}
 	return a.runPrompt()
+}
+
+func (a *App) runWeb(ctx context.Context) error {
+	srv := web.NewServer(web.Config{
+		Addr:   a.cfg.WebAddr,
+		Model:  a.cfg.Model,
+		Agent:  a.agent,
+		Policy: &a.cfg.Policy,
+		ErrOut: a.cfg.Stderr,
+	})
+	return srv.Run(ctx)
 }
 
 func (a *App) runRepl(ctx context.Context) error {

--- a/internal/web/index_html.go
+++ b/internal/web/index_html.go
@@ -1,0 +1,73 @@
+package web
+
+const indexHTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Jorin Web</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 0; background: #0f172a; color: #e2e8f0; }
+    .wrap { max-width: 980px; margin: 0 auto; padding: 20px; }
+    h1 { margin-top: 0; }
+    .chat { border: 1px solid #334155; border-radius: 8px; background: #111827; min-height: 360px; padding: 12px; overflow-y: auto; }
+    .msg { margin: 10px 0; white-space: pre-wrap; }
+    .user { color: #93c5fd; }
+    .assistant { color: #86efac; }
+    form { display: flex; gap: 8px; margin-top: 12px; }
+    input[type="text"] { flex: 1; padding: 10px; border-radius: 8px; border: 1px solid #334155; background: #0b1220; color: #e2e8f0; }
+    button { padding: 10px 14px; border-radius: 8px; border: 1px solid #334155; background: #1d4ed8; color: white; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Jorin Web Service</h1>
+    <p>Ask Jorin from your browser. Messages are kept in this tab only.</p>
+    <div id="chat" class="chat" aria-live="polite"></div>
+    <form id="chatForm">
+      <input id="prompt" type="text" placeholder="Ask Jorin to refactor, test, explain..." required />
+      <button type="submit">Send</button>
+    </form>
+  </div>
+  <script>
+    const chat = document.getElementById('chat');
+    const form = document.getElementById('chatForm');
+    const promptInput = document.getElementById('prompt');
+    const messages = [];
+
+    function append(role, content) {
+      const div = document.createElement('div');
+      div.className = 'msg ' + role;
+      div.textContent = (role === 'user' ? 'You: ' : 'Jorin: ') + content;
+      chat.appendChild(div);
+      chat.scrollTop = chat.scrollHeight;
+    }
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const prompt = promptInput.value.trim();
+      if (!prompt) return;
+
+      messages.push({ role: 'user', content: prompt });
+      append('user', prompt);
+      promptInput.value = '';
+
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages })
+      });
+      if (!response.ok) {
+        const err = await response.text();
+        append('assistant', 'Error: ' + err);
+        return;
+      }
+
+      const data = await response.json();
+      messages.push({ role: 'assistant', content: data.reply });
+      append('assistant', data.reply);
+    });
+  </script>
+</body>
+</html>
+`

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,0 +1,153 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dave1010/jorin/internal/agent"
+	"github.com/dave1010/jorin/internal/prompt"
+	"github.com/dave1010/jorin/internal/types"
+)
+
+const defaultAddr = "127.0.0.1:8080"
+
+// Config configures the web server mode.
+type Config struct {
+	Addr   string
+	Model  string
+	Agent  agent.Agent
+	Policy *types.Policy
+	ErrOut io.Writer
+}
+
+// Server serves the browser UI and JSON chat API.
+type Server struct {
+	cfg Config
+}
+
+// NewServer creates a web server with sensible defaults.
+func NewServer(cfg Config) *Server {
+	if strings.TrimSpace(cfg.Addr) == "" {
+		cfg.Addr = defaultAddr
+	}
+	return &Server{cfg: cfg}
+}
+
+// Run starts the HTTP server and shuts down cleanly when the context is canceled.
+func (s *Server) Run(ctx context.Context) error {
+	if s.cfg.Agent == nil {
+		return errors.New("web server requires an agent")
+	}
+	handler := s.routes()
+	srv := &http.Server{
+		Addr:              s.cfg.Addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		if s.cfg.ErrOut != nil {
+			_, _ = fmt.Fprintf(s.cfg.ErrOut, "Jorin web UI listening on http://%s\n", s.cfg.Addr)
+		}
+		err := srv.ListenAndServe()
+		if !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+		<-errCh
+		return nil
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (s *Server) routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleIndex)
+	mux.HandleFunc("/api/chat", s.handleChat)
+	mux.HandleFunc("/healthz", s.handleHealth)
+	return mux
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatRequest struct {
+	Messages []chatMessage `json:"messages"`
+	Prompt   string        `json:"prompt"`
+}
+
+type chatResponse struct {
+	Reply string `json:"reply"`
+}
+
+func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req chatRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	msgs := []types.Message{{Role: "system", Content: prompt.SystemPrompt()}}
+	for _, msg := range req.Messages {
+		role := strings.TrimSpace(msg.Role)
+		if role != "user" && role != "assistant" {
+			http.Error(w, "messages role must be user or assistant", http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(msg.Content) == "" {
+			continue
+		}
+		msgs = append(msgs, types.Message{Role: role, Content: msg.Content})
+	}
+	if p := strings.TrimSpace(req.Prompt); p != "" {
+		msgs = append(msgs, types.Message{Role: "user", Content: req.Prompt})
+	}
+	if len(msgs) < 2 {
+		http.Error(w, "prompt is required", http.StatusBadRequest)
+		return
+	}
+
+	_, out, err := s.cfg.Agent.ChatSession(s.cfg.Model, msgs, s.cfg.Policy)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(chatResponse{Reply: out}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = io.WriteString(w, "ok")
+}
+
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = io.WriteString(w, indexHTML)
+}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1,0 +1,87 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dave1010/jorin/internal/types"
+)
+
+type fakeAgent struct {
+	out      string
+	err      error
+	calls    int
+	lastMsgs []types.Message
+}
+
+func (f *fakeAgent) ChatSession(model string, msgs []types.Message, pol *types.Policy) ([]types.Message, string, error) {
+	f.calls++
+	f.lastMsgs = append([]types.Message(nil), msgs...)
+	return nil, f.out, f.err
+}
+
+func TestHandleIndex(t *testing.T) {
+	srv := NewServer(Config{Agent: &fakeAgent{}, Model: "test"})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	srv.routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "Jorin Web Service") {
+		t.Fatalf("expected page title content, got %q", rr.Body.String())
+	}
+}
+
+func TestHandleChat(t *testing.T) {
+	agent := &fakeAgent{out: "hello from jorin"}
+	srv := NewServer(Config{Agent: agent, Model: "test"})
+
+	body := map[string]any{
+		"messages": []map[string]string{{"role": "user", "content": "say hi"}},
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewReader(data))
+	rr := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if agent.calls != 1 {
+		t.Fatalf("expected one agent call, got %d", agent.calls)
+	}
+	if len(agent.lastMsgs) < 2 || agent.lastMsgs[1].Content != "say hi" {
+		t.Fatalf("expected forwarded prompt, got %#v", agent.lastMsgs)
+	}
+
+	var resp chatResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if resp.Reply != "hello from jorin" {
+		t.Fatalf("expected reply, got %q", resp.Reply)
+	}
+}
+
+func TestHandleChatRejectsInvalidRole(t *testing.T) {
+	srv := NewServer(Config{Agent: &fakeAgent{out: "ok"}, Model: "test"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", strings.NewReader(`{"messages":[{"role":"system","content":"nope"}]}`))
+	rr := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}


### PR DESCRIPTION
### Motivation

- Provide an easy way to run Jorin as a local web service so users can interact from a browser or via HTTP rather than only the CLI or REPL.
- Expose a simple JSON chat API for programmatic integrations and a small browser UI for quick manual use.
- Keep the existing CLI and REPL behavior unchanged while wiring the same agent and policy plumbing into web mode.

### Description

- Added CLI flags `--web` and `--web-addr` and propagated them through `cmd/jorin` into `app.Config` so the application can enter web mode without resolving prompt input. (files: `cmd/jorin/cli.go`, `cmd/jorin/main.go`)
- Extended `internal/app` to support a `runWeb` path that constructs and runs a new `internal/web` server using the existing `agent` and policy objects. (file: `internal/app/app.go`)
- Implemented `internal/web` package with an HTTP server that supports graceful start/shutdown and these endpoints: `GET /` (browser UI), `POST /api/chat` (JSON chat API with role validation and system prompt injection), and `GET /healthz` (health check), plus an embedded single-file browser UI. (files: `internal/web/server.go`, `internal/web/index_html.go`)
- Added unit tests for the web handlers and request validation. (file: `internal/web/server_test.go`)
- Updated documentation and changelog to document web mode and the new endpoints. (files: `README.md`, `docs/usage.md`, `CHANGELOG.md`)

### Testing

- Ran `make fmt` which completed successfully. 
- Ran `make test` and all packages including `internal/web` passed their unit tests. 
- Ran `make lint` with `golangci-lint` which reported no issues. 
- Built the binary with `make` which produced the `jorin` executable successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8ade23df4832b8835d43cb3696696)